### PR TITLE
fixes missing eigen_conversions pkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   moveit_visual_tools
   moveit_ros_move_group
+  eigen_conversions
   roscpp
   roslint
   rospy
@@ -40,6 +41,7 @@ catkin_package(
     moveit_ros_planning
     moveit_ros_move_group
     moveit_visual_tools
+    eigen_conversions
   INCLUDE_DIRS
     include
   LIBRARIES

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>roscpp</depend>
   <depend>roslint</depend>
   <depend>rospy</depend>
+  <depend>eigen_conversions</depend>
   <depend version_eq="3.9">clang-format</depend>
 
   <test_depend version_gte="1.11.2">pluginlib</test_depend>


### PR DESCRIPTION
@JafarAbdi found that moveit no longer uses the eigen_conversions pkg and descartes_capability does not explicitly export it.
Issue: https://github.com/ros-planning/moveit/issues/2733 + fixes #11 